### PR TITLE
Bump minimum CMake version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@
 # limitations under the License.
 ################################################################################
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 include(CMakeDependentOption)
 
 if(POLICY CMP0054)


### PR DESCRIPTION
CMake 3.0 is from 2014, 3.5 was released in 2018.
With CMake  3.27.1 I'm getting this warning:
```
CMake Deprecation Warning at extern/audaspace/CMakeLists.txt:17 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.
```
Every time Blender is configured.

----

An alternative would be to only use `cmake_minimum_required` when `AUDASPACE_STANDALONE` is true, although there is some small chance a project that embeds audaspace uses an older version of CMake.